### PR TITLE
Minor secrity fix

### DIFF
--- a/content/blog/fossee-silver-sponsor.md
+++ b/content/blog/fossee-silver-sponsor.md
@@ -6,6 +6,6 @@ Summary: Silver Sponsor FOSSEE
 
 **[FOSSEE (Free and Open Source Software in Education) project](http://fossee.in/)** promotes the use of FOSS tools to improve the quality of education in India. FOSSEE aims to reduce dependency on proprietary software in educational institutions. FOSSEE encourages the use of Free and Open Source Software(FOSS) through various activities to ensure commercial software is replaced by equivalent **FOSS tools**. FOSSEE also develops new FOSS tools and upgrade existing tools to meet requirements in academia and research.
 
-<img height="300" width="300" src="http://fossee.in/sites/all/themes/software_responsive_theme/img/logo.png">
+<img height="300" width="300" src="https://in.pycon.org/2017/images/sponsor/fossee.png">
 
 The FOSSEE project is part of the National Mission on Education through Information and Communication Technology (ICT), Ministry of Human Resources and Development, Government of India. **[Python team](http://python.fossee.in/)** is part of the FOSSEE (Free & Open Source Software for Education) project at IIT Bombay. FOSSEE, in turn is a part of the National Mission on Education through ICT with the thrust area being "Adaptation and deployment of open source simulation packages equivalent to proprietary software” funded by MHRD. 


### PR DESCRIPTION
One of the blog to announce FOSSEE as a sponsor was using an image from an HTTP website which gave a warning. This was needed to be resolved by linking the image from in.pycon.org.
![image](https://user-images.githubusercontent.com/10004530/32137995-8c7a99bc-bc48-11e7-951c-e5e8bcac70b0.png)
![image](https://user-images.githubusercontent.com/10004530/32137996-961a968e-bc48-11e7-830e-52dff8f81ae3.png)
