### PR TITLE
[Feature] Add Author tag to blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,19 @@ Thank you for your you interest in contributing to PyCon India blog site, please
 
 ## New Blog
 
-To create a new blog or page create a file in contents like `touch blog/my-new-blog.rst`.
-
-example of content can be:
+To create a new blog, create a markdown file (.md) in the `content/blog` directory. For Pelican to parse the content properly, make sure the Metadata syntax at the start of your new blog is follows the pattern given below:
 
 ```
-Test Article
-###############
+Title: Announcing X as Titanium Sponsor
+Date: 2020-05-10 10:00
+Author: John Doe
+Category: 2020
 
-:Date: 2015-3-03 10:20
-:Category: 2015
+We are happy to introduce our Titanium sponsor **X**! This is also the summary line that will be displayed on the index page.
 
-This can be removed as soon as more, real articles are added.
+<!-- PELICAN_END_SUMMARY -->
+
+Blog content goes here in the following lines.
 ```
 
-For more details look up, http://docs.getpelican.com/en/3.5.0/content.html
+For more details look up, https://docs.getpelican.com/en/4.2.0/content.html

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Title: Announcing X as Titanium Sponsor
 Date: 2020-05-10 10:00
 Author: John Doe
 Category: 2020
+Slug: announcing-X-as-titanium-sponsor
 
 We are happy to introduce our Titanium sponsor **X**! This is also the summary line that will be displayed on the index page.
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 
-AUTHOR = u'PSSI'
+AUTHOR = u'PyCon India Content Team'
 SITENAME = u'In PyCon Blog'
 SITEURL = '/blog'
 

--- a/themes/inpycon2019/templates/article.html
+++ b/themes/inpycon2019/templates/article.html
@@ -8,10 +8,12 @@
 
     <div class='meta'>
       <time datetime="{{article.date}}" itemprop="datePublished">
-	<small>Published: {{ article.date.strftime('%B %d, %Y') }}</small>
+	    <small>
+          Published: {{ article.date.strftime('%B %d, %Y') }}  |  Author: {{ article.author | default("PyCon India Content Team", true) }}
+        </small>
       </time>
     </div>
 
-    <div> {{ article.content }}</div>
+    <div>{{ article.content }}</div>
 </article>
 {% endblock %}

--- a/themes/inpycon2019/templates/index.html
+++ b/themes/inpycon2019/templates/index.html
@@ -10,7 +10,9 @@
 
         <div class="meta">
           <time datetime="{{article.date}}" itemprop="datePublished">
-            <small>Published: {{ article.date.strftime("%B %d, %Y") }}</small>
+            <small>
+              Published: {{ article.date.strftime("%B %d, %Y") }} | Author: {{ article.author | default("PyCon India Content Team", true) }}
+            </small>
           </time>
         </div>
 


### PR DESCRIPTION
Solves #263 

This is how it looks with a default value when the tag is either blank or not present in the blogs
![Screenshot_2020-05-10_03-29-47](https://user-images.githubusercontent.com/22801822/81485896-8e51ba00-926e-11ea-8d30-9466dfd60953.png)

This is how it looks with author name added as bro
![Screenshot_2020-05-10_03-12-14](https://user-images.githubusercontent.com/22801822/81485882-711ceb80-926e-11ea-9e19-df21bbcd2da9.png)

@pythonindia/pycon-india-2020 